### PR TITLE
Revert "Allow apps to read auxiliary camera properties"

### DIFF
--- a/common/private/appdomain.te
+++ b/common/private/appdomain.te
@@ -1,1 +1,0 @@
-get_prop(appdomain, vendor_persist_camera_prop)


### PR DESCRIPTION
This reverts commit 1c8088af9e7b504955293e94559245dd61ad5da4.

Some devices fail with this sepolicy, since there is no such property.
trees should instead add sepolicy in their own sepolicy rules.